### PR TITLE
fix: correct EarningsCallTranscript model to match API spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finnhub"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Jeffrey Brown"]
 description = "A comprehensive Rust client for the Finnhub.io financial data API with 96% endpoint coverage, flexible rate limiting, and WebSocket support"

--- a/src/endpoints/stock/filings.rs
+++ b/src/endpoints/stock/filings.rs
@@ -299,6 +299,23 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires API key"]
+    async fn test_transcript() {
+        let client = test_client().await;
+        let result = client.stock().transcripts("AAPL_162777").await;
+
+        assert!(
+            result.is_ok(),
+            "Failed to get transcript: {:?}",
+            result.err()
+        );
+
+        let transcript = result.unwrap();
+        assert!(!transcript.transcript.is_empty(), "Transcript should have content");
+        assert!(!transcript.participant.is_empty(), "Transcript should have participants");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires API key"]
     async fn test_earnings_call_live() {
         let client = test_client().await;
         // Look for earnings calls in the next 30 days

--- a/src/models/stock/filings.rs
+++ b/src/models/stock/filings.rs
@@ -57,47 +57,59 @@ pub struct InternationalFiling {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EarningsCallTranscript {
     /// Symbol.
+    #[serde(default)]
     pub symbol: String,
-    /// Transcript data.
+    /// Transcript content.
+    #[serde(default)]
     pub transcript: Vec<TranscriptSegment>,
     /// Participant list.
+    #[serde(default)]
     pub participant: Vec<TranscriptParticipant>,
     /// Audio link.
+    #[serde(default)]
     pub audio: String,
     /// Transcript ID.
+    #[serde(default)]
     pub id: String,
     /// Title.
+    #[serde(default)]
     pub title: String,
-    /// Time.
+    /// Time of the event.
+    #[serde(default)]
     pub time: String,
     /// Year.
+    #[serde(default)]
     pub year: i32,
     /// Quarter.
+    #[serde(default)]
     pub quarter: i32,
 }
 
-/// Transcript segment.
+/// Transcript content segment (a single speaker's contribution).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptSegment {
-    /// Speaker name.
+    /// Speaker's name.
+    #[serde(default)]
     pub name: String,
-    /// Speaker position.
-    pub position: String,
-    /// Start time.
-    #[serde(rename = "startTime")]
-    pub start_time: i32,
-    /// Speech content.
-    pub speech: String,
+    /// Speaker's speech as array of paragraphs.
+    #[serde(default)]
+    pub speech: Vec<String>,
+    /// Earnings call section (e.g. "Management Discussion" or "Q&A").
+    #[serde(default)]
+    pub session: String,
 }
 
 /// Transcript participant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptParticipant {
-    /// Participant name.
+    /// Participant's name.
+    #[serde(default)]
     pub name: String,
-    /// Participant description.
+    /// Participant's description.
+    #[serde(default)]
     pub description: String,
-    /// Participant role.
+    /// Whether the speaker is a company executive or an analyst.
+    #[serde(default)]
     pub role: String,
 }
 


### PR DESCRIPTION
## Summary
- Fixed `TranscriptSegment` model to match the actual Finnhub `/stock/transcripts` API response
  - `speech`: `String` → `Vec<String>` (API returns array of paragraphs)
  - `position` → `session` (earnings call section: management discussion or Q&A)
  - Removed `start_time` / `startTime` (not in API spec)
- Added `#[serde(default)]` to all `EarningsCallTranscript`, `TranscriptSegment`, and `TranscriptParticipant` fields for null safety
- Added missing `test_transcript` integration test
- Bumps version to 0.2.2

## Root cause
The model was generated speculatively without a corresponding integration test. The `test_transcripts_list` test existed but no `test_transcript` (singular) test, so the incorrect field definitions went unvalidated.

## Test plan
- [x] `cargo build` passes
- [ ] `cargo test --ignored -- test_transcript` with API key to validate against real API

🤖 Generated with [Claude Code](https://claude.com/claude-code)